### PR TITLE
fix: be explicit about exported types so declaration emission works

### DIFF
--- a/addon/-private/yield-wrapper.ts
+++ b/addon/-private/yield-wrapper.ts
@@ -24,7 +24,7 @@ export default class YieldWrapper extends ReactComponent<YieldWrapperProps> {
     element.parentNode!.replaceChild(fragment, element);
   }
 
-  render() {
+  render(): any {
     // This element is temporary. When this is mounted,
     // it will be replaced by the children nodes, handled by Ember.
     return createElement('span', {

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -16,7 +16,7 @@ interface ComponentAttributes {
 
 export default function WithEmberSupport<T extends Constructor<ReactComponent>>(
   Klass: T
-) {
+): typeof EmberComponent {
   return class extends EmberComponent {
     /* Add type annotation for private `attrs` property on component */
     private attrs!: ComponentAttributes;


### PR DESCRIPTION
This should make `tsc` happy when emitting type declarations. For `render()`, rather than using `any` you could also add a couple imports and explicitly make the return type `DetailedReactHTMLElement<HTMLAttributes<HTMLElement>, HTMLElement>`. 