### PR TITLE
Add support for .jsx extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const configureJsxTransform = require('./lib/configure-jsx-transform');
+const addJsxExtensionSupport = require('./lib/add-jsx-extension-support');
 
 module.exports = {
   name: require('./package').name,
@@ -9,5 +10,6 @@ module.exports = {
     this._super.included.apply(this, arguments);
 
     configureJsxTransform(parent);
+    addJsxExtensionSupport(parent);
   }
 };

--- a/lib/add-jsx-extension-support.js
+++ b/lib/add-jsx-extension-support.js
@@ -1,0 +1,12 @@
+module.exports = function addJsxExtensionSupport(parent) {
+  if (parent.options['ember-cli-babel']['extensions']) {
+    if (!parent.options['ember-cli-babel']['extensions'].includes('js')) {
+      parent.options['ember-cli-babel']['extensions'].push('js');
+    }
+    if (!parent.options['ember-cli-babel']['extensions'].includes('jsx')) {
+      parent.options['ember-cli-babel']['extensions'].push('jsx');
+    }
+  } else {
+    parent.options['ember-cli-babel']['extensions'] = ['js', 'jsx'];
+  }
+};


### PR DESCRIPTION
This PR updates the parent application's ember-cli-babel configuration to allow components with `.jsx` to be recognized. 